### PR TITLE
List of terms

### DIFF
--- a/_includes/js/list-js.html
+++ b/_includes/js/list-js.html
@@ -1,0 +1,87 @@
+{%- comment -%}
+
+    Generates a list-group using js to process the terms for display on "list" layout.
+    Requires CB's array_count_uniq.rb plugin!
+    
+{%- endcomment -%}
+{% if site.data.theme.browse-child-objects == true %}
+{%- assign items = site.data[site.metadata] | where_exp: 'item','item.objectid' -%}
+{% else %}
+{%- assign items = site.data[site.metadata] | where_exp: 'item','item.objectid and item.parentid == nil' -%}
+{% endif %}
+{%- assign termsMin = include.min | plus: 0 | default: 1 -%}
+{%- assign list_id = include.id | default: "list-group" -%}
+{%- assign list-fields = include.fields | split: ";" -%}
+
+{%- comment -%} capture terms from all list fields {%- endcomment -%}
+{%- assign terms = "" -%}
+{%- for c in list-fields -%}
+{% assign new = items | map: c | join: ";" %}
+{% assign terms = terms | append: ";" | append: new %}
+{%- endfor -%}
+{%- comment -%} find unique terms and counts {%- endcomment -%}
+{%- assign uniqTerms = terms | downcase | split: ";" | array_count_uniq | sort | where_exp: 't','t[1] >= termsMin' -%}
+
+<script>  
+    var currentSortMethod = 'count';
+
+    /* subject terms + count */
+    var terms = [
+        {% for t in uniqTerms %}[{{ t[0] | jsonify }}, {{ t[1] | jsonify }}]{% unless forloop.last %}, {% endunless %}{% endfor %}
+    ];
+
+    {% if include.stopwords %}/* apply stopwords */
+    var stopWords = {{ include.stopwords | downcase | split: ';' | jsonify }};
+    terms = terms.filter(function(a) { return stopWords.indexOf(a[0]) < 0;});{% endif %}
+    
+    /* sort terms */
+    function sortTerms(sortMethod) {
+        if (sortMethod === 'count') {
+            terms.sort(function(a, b) {
+                return b[1] - a[1];
+            });
+        } else if (sortMethod === 'term') {
+            terms.sort(function(a, b) {
+                return a[0].localeCompare(b[0]);
+            });
+        }
+    }
+
+    /* create list-group */
+    function makeList(array) {
+        var items = "";
+        for (var i = 0; i < array.length; i++) {
+            items += '<a href="{{ "/browse.html" | relative_url }}#' + encodeURIComponent(array[i][0]) + '" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center text-primary">' + array[i][0] + ' <span class="badge bg-primary rounded-pill">' + array[i][1] + '</span></li>';
+        }
+        var listGroup = document.getElementById("{{ list_id }}");
+        listGroup.innerHTML = items;
+    }
+
+    /* toggle sorting method */
+    function changeSortMethod(sortMethod) {
+        currentSortMethod = sortMethod;
+        sortTerms(currentSortMethod);
+        makeList(terms);
+        document.getElementById('sortFilter').innerText = capitalizeFirstLetter(sortMethod);
+
+        // Remove 'active' class from all items
+        var items = document.querySelectorAll('.list-sort-item');
+        items.forEach(function(item) {
+            item.classList.remove('active');
+        });
+
+        // Add 'active' class to the selected item
+        var selected = document.querySelector('.list-sort-item[onclick="changeSortMethod(\'' + sortMethod + '\')"]');
+        if (selected) {
+            selected.classList.add('active');
+        }
+    }
+
+    function capitalizeFirstLetter(string) {
+        return string.charAt(0).toUpperCase() + string.slice(1);
+    }
+
+    /* initial sorting */
+    sortTerms(currentSortMethod);
+    makeList(terms);
+</script>

--- a/_layouts/list.html
+++ b/_layouts/list.html
@@ -1,22 +1,30 @@
 ---
+# Term list layout
+# can be used by subjects and location page
+# can be used for any metadata field
 layout: page
 ---
 
 {{ content }}
 
+{%- comment -%}
 
-{%- if page.cloud-fields == "site.data.theme.subjects-fields" -%}
+    Figure out default "Subjects" and "Locations" page field values as configured in in "theme.yml", 
+    and set default values for field include.
+
+{%- endcomment -%}
+{%- if page.fields == "site.data.theme.subjects-fields" -%}
   {% assign fields = site.data.theme.subjects-fields %}
   {% assign min = site.data.theme.subjects-min | default: 1 %}
   {% assign stopwords = site.data.theme.subjects-stopwords %}
-{%- elsif page.cloud-fields == "site.data.theme.locations-fields" -%}
+{%- elsif page.fields == "site.data.theme.locations-fields" -%}
   {% assign fields = site.data.theme.locations-fields %}
   {% assign min = site.data.theme.locations-min | default: 1 %}
   {% assign stopwords = site.data.theme.locations-stopwords %}
 {%- else -%}
-  {% assign fields = page.cloud-fields | default: "subjects" %}
-  {% assign min = page.cloud-min | default: 1 %}
-  {% assign stopwords = page.cloud-stopwords %}
+  {% assign fields = page.fields | default: "subjects" %}
+  {% assign min = page.field-min | default: 1 %}
+  {% assign stopwords = page.field-stopwords %}
 {%- endif -%}
 
 {% assign list_id = "list-div-" | append: fields | slugify %}

--- a/_layouts/list.html
+++ b/_layouts/list.html
@@ -1,0 +1,33 @@
+---
+layout: page
+---
+
+{{ content }}
+
+
+{%- if page.cloud-fields == "site.data.theme.subjects-fields" -%}
+  {% assign fields = site.data.theme.subjects-fields %}
+  {% assign min = site.data.theme.subjects-min | default: 1 %}
+  {% assign stopwords = site.data.theme.subjects-stopwords %}
+{%- elsif page.cloud-fields == "site.data.theme.locations-fields" -%}
+  {% assign fields = site.data.theme.locations-fields %}
+  {% assign min = site.data.theme.locations-min | default: 1 %}
+  {% assign stopwords = site.data.theme.locations-stopwords %}
+{%- else -%}
+  {% assign fields = page.cloud-fields | default: "subjects" %}
+  {% assign min = page.cloud-min | default: 1 %}
+  {% assign stopwords = page.cloud-stopwords %}
+{%- endif -%}
+
+{% assign list_id = "list-div-" | append: fields | slugify %}
+<div class="dropdown">
+  <button class="btn btn-secondary mt-1 dropdown-toggle" type="button" id="browseSortButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      Sort by <span id="sortFilter">Count</span>
+  </button>
+  <div class="dropdown-menu browse-sort-menu" aria-labelledby="browseSortButton">
+      <button class="dropdown-item list-sort-item active" onclick="changeSortMethod('count')">Count</button>
+      <button class="dropdown-item list-sort-item" onclick="changeSortMethod('term')">Term</button>
+  </div>
+</div>
+<div id="{{ list_id }}" class="text-center my-4 bg-{{ page.background | default: 'light' }} border rounded p-2"></div>
+{% include js/list-js.html id=list_id fields=fields min=min stopwords=stopwords %}

--- a/_layouts/list.html
+++ b/_layouts/list.html
@@ -21,13 +21,13 @@ layout: page
 
 {% assign list_id = "list-div-" | append: fields | slugify %}
 <div class="dropdown">
-  <button class="btn btn-secondary mt-1 dropdown-toggle" type="button" id="browseSortButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      Sort by <span id="sortFilter">Count</span>
-  </button>
-  <div class="dropdown-menu browse-sort-menu" aria-labelledby="browseSortButton">
-      <button class="dropdown-item list-sort-item active" onclick="changeSortMethod('count')">Count</button>
-      <button class="dropdown-item list-sort-item" onclick="changeSortMethod('term')">Term</button>
-  </div>
+    <button class="btn btn-secondary mt-1 dropdown-toggle" type="button" id="browseSortButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        Sort by <span id="sortFilter">Count</span>
+    </button>
+    <div class="dropdown-menu browse-sort-menu" aria-labelledby="browseSortButton">
+        <button class="dropdown-item list-sort-item active" onclick="changeSortMethod('count')">Count</button>
+        <button class="dropdown-item list-sort-item" onclick="changeSortMethod('term')">Term</button>
+    </div>
 </div>
 <div id="{{ list_id }}" class="text-center my-4 bg-{{ page.background | default: 'light' }} border rounded p-2"></div>
 {% include js/list-js.html id=list_id fields=fields min=min stopwords=stopwords %}

--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -2,29 +2,24 @@
 
 ## Built-in clouds
 
-For simplicity, the default CB theme has two pre-configured cloud visualization pages pre-configured named "Subjects" and "Locations". 
-These can be configured using variables in the "_data/theme.yml" to generate clouds from any field(s) in your metadata (not necessarily just a "subject" or "location" field). 
+For simplicity, the default CB theme has a pre-configured cloud visualization page pre-configured named "Locations". 
+These can be configured using variables in the "_data/theme.yml" to generate clouds from any field(s) in your metadata (not necessarily just a "location" field). 
 The theme options look like:
 
 ```
-# Subject page
-subjects-fields: subject;creator # set of fields separated by ; to be featured in the cloud
-subjects-min: 1 # min size for subject cloud, too many terms = slow load time!
-subjects-stopwords: # set of subjects separated by ; that will be removed from display, e.g. boxers;boxing
-
 # Locations page
 locations-fields: location # set of fields separated by ; to be featured in the cloud
 locations-min: 1 # min size for subject cloud, too many terms = slow load time!
 locations-stopwords: # set of subjects separated by ; that will be removed from display, e.g. boxers;boxing
 ```
 
-The files "pages/subjects.md" and "pages/locations.md" pull in these values to create the default cloud pages.
+The file "pages/locations.md" pulls in these values to create the default cloud page.
 The settings also create matching data outputs in the "/assets/data/" folder.
 
-If `subjects-fields` or `locations-fields` is blank or commented out, the template will not build out the related cloud page or data, which saves build time. 
+If `locations-fields` is blank or commented out, the template will not build out the related cloud page or data, which saves build time. 
 If you are developing a particularly large collection, you can comment out these options to make rebuild much quicker. 
 
-Keep in mind these page stubs (`/subjects.html`, `/locations.html`) will also have to be present in "config-nav.csv" to show up in your navigation, and to have the data files to show up in data download options. 
+Keep in mind this page stub (`/locations.html`) will also have to be present in "config-nav.csv" to show up in your navigation, and to have the data files to show up in data download options. 
 
 ## Cloud Layout and Front matter
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ color_theme.md
 
 item_pages.md
 cloud.md
+list.md
 data.md
 maps.md
 navbar.md

--- a/docs/list.md
+++ b/docs/list.md
@@ -1,0 +1,51 @@
+# Create List Visualizations
+
+## Built-in lists
+
+For simplicity, the default CB theme has a pre-configured list visualization page pre-configured named "Subjects". 
+These can be configured using variables in the "_data/theme.yml" to generate the list from any field(s) in your metadata (not necessarily just a "subject" field). 
+The theme options look like:
+
+```
+# Subject page
+subjects-fields: subject;creator # set of fields separated by ; to be featured in the list
+subjects-min: 1 # min size for subject list, too many terms = slow load time!
+subjects-stopwords: # set of subjects separated by ; that will be removed from display, e.g. boxers;boxing
+```
+
+The file "pages/subjects.md" pulls in these values to create the default list page.
+The settings also create matching data outputs in the "/assets/data/" folder.
+
+If `subjects-fields` is blank or commented out, the template will not build out the related list page or data, which saves build time. 
+If you are developing a particularly large collection, you can comment out these options to make rebuild much quicker. 
+
+Keep in mind this page stub (`/subjects.html`) will also have to be present in "config-nav.csv" to show up in your navigation, and to have the data files to show up in data download options. 
+
+## List Layout and Front matter
+
+Custom list pages can be easily created using the list layout and page front matter.
+Create a new page stub with standard front matter, and add these values: 
+
+- `fields:`, with a value of a set of fields separated by `;` to be featured in the list.
+- `min:` (optional), with a integer value such as `2`.
+- `stopwords:` (optional), with a set of terms separated by `;` that will be removed from display.
+
+For example, to create an "Authors" list page, create a file named "authors.md" in the "pages" folder. 
+Edit the "authors.md" with this front matter and content:
+
+```
+---
+title: Authors
+layout: list
+permalink: /authors.html
+fields: creator
+min: 
+stopwords:
+---
+
+## Browse Authors
+
+Example custom list page.
+```
+
+

--- a/pages/subjects.md
+++ b/pages/subjects.md
@@ -3,8 +3,8 @@ title: Subjects
 layout: list
 permalink: /subjects.html
 # Default subject page is configured in "_data/theme.yml"
-# leave cloud-fields as "site.data.theme.subjects-fields"
-cloud-fields: site.data.theme.subjects-fields
+# leave fields as "site.data.theme.subjects-fields"
+fields: site.data.theme.subjects-fields
 ---
 
 ## Browse Subjects

--- a/pages/subjects.md
+++ b/pages/subjects.md
@@ -1,6 +1,6 @@
 ---
 title: Subjects
-layout: cloud
+layout: list
 permalink: /subjects.html
 # Default subject page is configured in "_data/theme.yml"
 # leave cloud-fields as "site.data.theme.subjects-fields"
@@ -9,5 +9,4 @@ cloud-fields: site.data.theme.subjects-fields
 
 ## Browse Subjects
 
-Use this word cloud visualization to browse terms and subjects.
-Word size is determined by frequency and all words link to a corresponding collection search.
+


### PR DESCRIPTION
# Pull request

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

#11 
New layout for object fields in the form of a list.

All pages that previously used a wordcloud can now either be displayed as a wordcloud or as a list. To do so, just change the value of the layout in the corresponding markdown page from
```
layout: wordcloud
```
to
```
layout: list
```

The list shows the number of the respective term and can be sorted either by number or alphabetically by term.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a dynamic list-generation feature for displaying items with unique counts and sorting capabilities.
  - Implemented a new layout design for pages, including a dropdown sorting menu.

- **Content Updates**
  - Removed the description from the "Subjects" page to streamline the browsing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->