### PR TITLE
Revert "fix timeline"

### DIFF
--- a/_layouts/timeline_edtf.html
+++ b/_layouts/timeline_edtf.html
@@ -10,17 +10,16 @@ custom-foot: js/timeline-js.html
 {% else %}
   {%- assign items = site.data[site.metadata] | where_exp: 'item', 'item.objectid and item.parentid == nil' -%}
 {% endif %}
-{% assign regex = '[-]?[\dXu]{4,}' %}
 {%- assign items = items | where_exp: 'item', 'item[field]' -%}
 {%- assign raw-dates = items | map: field | compact | uniq -%}
+{% assign regex = '[\dX]{4}' %}
 {%- capture clean-years -%}{% for date in raw-dates %}{{date | regex_match: regex | join: ';' }}{% unless forloop.last %};{% endunless %}{%- endfor -%}{%- endcapture -%}
 {%- assign uniqueYears = clean-years | remove: ' ' | replace: ';;', ';' | split: ';' | uniq | sort -%}
-{% assign sorted_years = uniqueYears | sort_edtf %}
 {%- if site.data.theme['year-navigation'] -%}
   {%- assign navYears = site.data.theme['year-navigation'] | split: ';' -%}
 {%- elsif site.data.theme['year-nav-increment'] -%}
   {%- capture navYears -%}
-{%- for i in sorted_years -%}{%- assign t = i | modulo: site.data.theme.year-nav-increment -%}
+{%- for i in uniqueYears -%}{%- assign t = i | modulo: site.data.theme.year-nav-increment -%}
 {%- if t == 0 -%}{{ i }}{% unless forloop.last %};{% endunless %}{% endif %}{% endfor %}{%- endcapture -%}
   {%- assign navYears = navYears | split: ';' -%}
 {%- endif -%}
@@ -38,13 +37,8 @@ custom-foot: js/timeline-js.html
     </button>
     <div class="dropdown-menu" aria-labelledby="yearButton">
       {% for y in navYears %}
-        {% assign year_parts = y | split: ':' %}
-        {% if year_parts.size == 2 %}
-          <a class="dropdown-item" href="#y{{ year_parts[1] }}">{{ year_parts[0] }}</a>
-        {% else %}
-          <a class="dropdown-item" href="#y{{ y }}">{{ y }}</a>
-        {% endif %}
-      {% endfor %}
+        <a class="dropdown-item" href="#y{{ y }}">{{ y }}</a>
+      {%- endfor %}
     </div>
   </div>
 {%- endif -%}
@@ -52,25 +46,21 @@ custom-foot: js/timeline-js.html
 {{ content }}
 
 <h2>
-  {% assign first_year = sorted_years | first | split: ':' %}
-  {% assign last_year = sorted_years | last | split: ':' %}
-  {% if first_year.size == 2 and last_year.size == 2 %}
-    <a href="#y{{ first_year[1] }}">{{ first_year[0] }}</a> &#8211;
-    <a href="#y{{ last_year[1]}}">{{ last_year[0] }}</a>
-  {% endif %}
+  <a href="#y{{ uniqueYears | first }}">{{ uniqueYears | first }}</a>&#8211;<a href="#y{{ uniqueYears | last }}">
+    {{- uniqueYears | last -}}
+  </a>
 </h2>
 
 <table id="timeline" class="table table-striped">
   <tbody>
-    {% for date in sorted_years %}
-      {% assign year = date | split: ':' %}
-      <tr id="y{{ year[1] }}">
+    {% for year in uniqueYears %}
+      <tr id="y{{ year }}">
         <th>
-          <h3>{{ year[0] }}</h3>
+          <h3>{{ year }}</h3>
         </th>
         <td>
           <div class="row">
-            {%- assign inYear = items | filter_items_by_year: year[1], '[-]?[\dXu]{4,}' -%}
+            {%- assign inYear = items | where_exp: 'item', 'item[field] contains year' -%}
             {% for item in inYear %}
               <div class="col-lg-4 col-md-6">
                 <figure class="figure">

--- a/_plugins/jekyll_regex_match.rb
+++ b/_plugins/jekyll_regex_match.rb
@@ -20,36 +20,6 @@ module Jekyll
             return nil
           end
         end
-
-        def filter_items_by_year(items, year, regex_pattern = '[-]?[\dXu]{4,}')
-          raise ArgumentError, 'Regex pattern too complex' if regex_pattern.length > 50
-          return [] unless items.is_a?(Array) && !year.nil?
-          begin
-
-          # Clear cache if it grows too large
-          if defined?(@cache_size) && @cache_size > 1000
-            items.each { |item| item.delete('cached_dates') }
-            @cache_size = 0
-          end
-
-          regex = Regexp.new(regex_pattern)  
-          items.select do |item|
-            next false unless item.is_a?(Hash) && item['date'].is_a?(String)
-
-            # Track cache size
-            @cache_size ||= 0
-            @cache_size += 1 unless item['cached_dates']
-
-            dates = item['cached_dates'] ||= item['date'].scan(regex).map(&:to_s) 
-            dates.include?(year)  
-          end
-          rescue RegexpError => e
-            Jekyll.logger.error "RegexMatch:", "Invalid regex pattern: #{e.message}"
-            # Handle invalid regex pattern
-            []
-          end
-        end
-
     end
   end
   

--- a/_plugins/sort_edtf.rb
+++ b/_plugins/sort_edtf.rb
@@ -1,47 +1,10 @@
 module Jekyll
-  module SortEDTF
-    def sort_edtf(array_of_strings)
-
-      # Remove any empty strings after stripping whitespace
-      valid_dates = array_of_strings.reject { |str| str.strip.empty? }
-
-      # Parse each string into a hash with numeric, original, and display representations
-      parsed_dates = valid_dates.map do |str|
-        cleaned_str = str.gsub(/[Xu]/, '0') # Replace X/x with 0 for numeric comparison
-        
-        # Remove leading zeros for numeric value calculation
-        numeric_value = if cleaned_str.start_with?('-')
-                          numeric_str = cleaned_str.sub(/^-0+/, '-')
-                        else
-                          numeric_str = cleaned_str.sub(/^0+/, '')
-                        end
-
-        # Validate that numeric_str is a valid integer
-        if numeric_str.match?(/^-?\d+$/)
-          numeric_value = numeric_str.to_i
-        else
-          raise ArgumentError, "Invalid date format: #{str}"
+    module SortEDTF
+        def sort_edtf(array_of_strings)
+            sorted = array_of_strings.map { |str| str.gsub('X', '0') }
+            sorted.sort_by { |str| str[/\d+/].to_i }
         end
-
-        # Create a human-readable display format
-        # For display format, we use the original string, just without leading zeros
-        display_format = if str.start_with?('-')
-                           "#{str[1..-1].sub(/^0+/, '')} v. Chr."  # For negative, remove minus and leading zeros for display
-                         else
-                           str.sub(/^0+/, '')  # Remove leading zeros for positive values
-                         end
-
-        # Return a hash with numeric, original, and display_format
-        { numeric: numeric_value, original: str, display_format: display_format }
-      end
-
-      # Sort by the numeric representation
-      sorted_dates = parsed_dates.sort_by { |date| date[:numeric] }
-
-      # Return an array of "display_format:original" strings
-      sorted_dates.map { |date| "#{date[:display_format]}:#{date[:original]}" }
     end
-  end
 end
   
 Liquid::Template.register_filter(Jekyll::SortEDTF)


### PR DESCRIPTION
Reverts Stadt-Geschichte-Basel/forschung.stadtgeschichtebasel.ch#171

There is still an error on the build process:
`  Liquid Exception: Liquid error (line 13): Invalid date format: 0000 in /home/runner/work/forschung.stadtgeschichtebasel.ch/forschung.stadtgeschichtebasel.ch/_layouts/timeline_edtf.html
                    ------------------------------------------------
      Jekyll 4.3.4   Please append `--trace` to the `build` command 
                     for any additional information or backtrace. 
                    ------------------------------------------------`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced date processing and display in the timeline layout for improved clarity.
	- Simplified dropdown navigation for years, making it more user-friendly.

- **Bug Fixes**
	- Removed redundant error handling and complex filtering logic for year items, streamlining functionality.

- **Refactor**
	- Simplified date sorting and formatting logic, resulting in a more efficient method for handling date strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->