### PR TITLE
CSV/Geodata Icons

### DIFF
--- a/.github/workflows/process_data.py
+++ b/.github/workflows/process_data.py
@@ -185,6 +185,10 @@ def extract_media_data(media, item_dc_identifier):
     # Download the thumbnail image if available and valid
     if "platzhalter" in media.get("o:source", ""):
         local_image_path = "assets/img/placeholder.svg"
+    elif "application/geo+json" in format_value:
+        local_image_path = "assets/lib/icons/sgb-globe.svg"
+    elif "text/csv" in format_value:
+        local_image_path = "assets/lib/icons/table.svg"
     else:
         local_image_path = (
             download_thumbnail(media.get("thumbnail_display_urls", {}).get("large", ""))

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -440,3 +440,14 @@ thead, tbody, th, td {
     object-fit: contain; /* to maintain aspect ratio */
     object-position: center;
 }
+
+.timeline-thumb[src$=".svg"] {
+    width: 100%;
+    height: 100%;
+}
+
+.compound-thumb[src$=".svg"] {
+    width: 100%;
+    height: 100%;
+    border: none;
+}


### PR DESCRIPTION
# Pull request

## Proposed changes

At some point, I think in 42dd6de, geodata items lost the globe icon added in #134 -- the processing script assigns the `assets/img/no-image.svg` icon to all items that do not have a thumbnail on Omeka, which geodata and tabular data do not have.

I changed the processing script so that items with formats `geo+json` and `csv` are directly assigned the local icon path as thumbnails instead of the placeholder. I'm not sure whether there are better steps in the pipeline to do this, but this seems to work for now. Also, this still bypasses the assignment of icons that is done in CB itself.

Also, I assigned the bootstrap table icon to csv items which did not have a separate icon before.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [x] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced media presentation by assigning more appropriate icons for different content types.
  
- **Style**
	- Improved styling of SVG images to ensure they scale optimally and display without unwanted borders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->