### PR TITLE
Child Object Sorting

### DIFF
--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -592,6 +592,10 @@ _layouts:
     compound-object.html:
     image.html:
     item-page-base.html:
+      item:
+        en: "Item"
+        es: "Elemento"
+        de: "Objekt"
       items:
         en: "Items"
         es: "Elementos"

--- a/_includes/item/child/compound-item-modal-gallery.html
+++ b/_includes/item/child/compound-item-modal-gallery.html
@@ -6,7 +6,7 @@
   This include requires the Liquid object "child" to be present! The item display requires the compound object item includes in "item/child/".
 {% endcomment %}
 <div class="row row-cols-2 row-cols-lg-4 g-2">
-  {% for child in children %}
+  {% for child in children | sort: 'objectid' %}
     <div class="col">
       <div class="card h-100">
         <div class="my-auto">

--- a/_includes/item/child/compound-item-modal-gallery.html
+++ b/_includes/item/child/compound-item-modal-gallery.html
@@ -6,7 +6,8 @@
   This include requires the Liquid object "child" to be present! The item display requires the compound object item includes in "item/child/".
 {% endcomment %}
 <div class="row row-cols-2 row-cols-lg-4 g-2">
-  {% for child in children | sort: 'objectid' %}
+  {%- assign children_sorted = children | sort: 'objectid' -%}
+  {% for child in children_sorted %}
     <div class="col">
       <div class="card h-100">
         <div class="my-auto">

--- a/_layouts/item/item-page-base.html
+++ b/_layouts/item/item-page-base.html
@@ -8,11 +8,14 @@ item-meta: true
 <div class="container py-3">
   {% include item/breadcrumbs.html %}
   <div class="my-0 h5 small">
-    {{ page.display_template | replace: '_', ' ' | upcase }}
     {% if page.display_template == 'compound_object' or page.display_template == 'multiple' -%}
-      {%- assign children = site.data[site.metadata] | where_exp: 'item', 'item.parentid == page.objectid' %} (
+      {%- assign children = site.data[site.metadata] | where_exp: 'item', 'item.parentid == page.objectid' %}
       {{- children | size }}
-      {{ site.data.translations._layouts.item['item-page-base.html'].items[site.lang] | default: 'Items' }})
+      {% if children.size == 1 %}
+        {{ site.data.translations._layouts.item['item-page-base.html'].item[site.lang] | default: 'Item' }}
+      {% else %}
+        {{ site.data.translations._layouts.item['item-page-base.html'].items[site.lang] | default: 'Items' }}
+      {% endif %}
     {%- endif %}
   </div>
   <h2 class="mb-3">

--- a/_layouts/item/item-page-full-width.html
+++ b/_layouts/item/item-page-full-width.html
@@ -11,8 +11,15 @@ item-meta: true
 <div class="container-fluid py-3">
   {% include item/breadcrumbs.html %}
   <div class="my-0 h5 small">
-    {{ page.display_template | replace: '_', ' ' | upcase }}
-    {% if page.display_template == 'compound_object' %} ({{ children | size }} Items){% endif %}
+    {% if page.display_template == 'compound_object' or page.display_template == 'multiple' -%}
+      {%- assign children = site.data[site.metadata] | where_exp: 'item', 'item.parentid == page.objectid' %}
+      {{- children | size }}
+      {% if children.size == 1 %}
+        {{ site.data.translations._layouts.item['item-page-base.html'].item[site.lang] | default: 'Item' }}
+      {% else %}
+        {{ site.data.translations._layouts.item['item-page-base.html'].items[site.lang] | default: 'Items' }}
+      {% endif %}
+    {%- endif %}
   </div>
   <h2 class="mb-3">
     {{ page.title }}

--- a/_layouts/timeline_edtf.html
+++ b/_layouts/timeline_edtf.html
@@ -185,7 +185,8 @@ custom-foot: js/timeline-js.html
         <td>
           <div class="row">
             {%- assign inYear = items | filter_items_by_year: year[1], '[-]?[\dXu]{4,}' -%}
-            {% for item in inYear %}
+            {%- assign inYear_sorted = inYear | sort: 'objectid' -%}
+            {% for item in inYear_sorted %}
               <div class="col-lg-4 col-md-6">
                 <figure class="figure">
                   <a href="{% if item.parentid == nil %}{{ '/items/' | append: item.objectid | append: '.html' | relative_url }}{% elsif item.parentid %}{{ '/items/' | append: item.parentid | append: '.html' | relative_url }}#{{item.objectid }}{% endif %}">


### PR DESCRIPTION
# Pull request

## Proposed changes

* fix #214 by sorting the items by `objectid` before showing them in the compound object modal gallery
* also do the same sorting on the timeline page

The goal is to achieve the same order of objects (PDF files first, then geodata) accross files regardless of changes (reuploads) on the Omeka server. This of course assumes that the PDF files are put on Omeka first with the lower SGB IDs (as has been the case so far).

See images:

Currently online gallery:
<img width="1512" alt="current_gallery" src="https://github.com/user-attachments/assets/9a211c61-31d6-4d6d-a57a-b6b30a565ef4" />

Fixed gallery:
<img width="1512" alt="fixed_gallery" src="https://github.com/user-attachments/assets/0d14ba75-067a-4131-b8ef-d2fffc4fe7aa" />

Currently online timeline:
<img width="1512" alt="current_timeline" src="https://github.com/user-attachments/assets/42182a4b-8171-46a8-9763-a6407dfa9218" />

Fixed timeline:
<img width="1512" alt="fixed_timeline" src="https://github.com/user-attachments/assets/d0c80d11-7d68-4e2e-87c9-5aafd79e65b1" />


## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [x] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying a singular or plural label ("Item"/"Items") based on the number of child items, with translations in English, Spanish, and German.
- **Improvements**
  - Child items and timeline entries are now consistently sorted by their object ID for a more predictable display order.
  - The count and label for child items are now shown more clearly, with improved handling for different templates and languages.
- **Style**
  - Removed display of template names and unnecessary parentheses for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->