### PR TITLE
Disable daily workflow schedule and unlink type field

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '0 0 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/process_data.py
+++ b/.github/workflows/process_data.py
@@ -90,12 +90,12 @@ def get_media(item_id):
 
 
 # --- Data Extraction and Transformation Functions ---
-def extract_property(props, prop_id, as_uri=False):
-    """Extracts a property value or URI from properties based on property ID."""
+def extract_property(props, prop_id, as_label=False):
+    """Extracts a property value or label from properties based on property ID."""
     for prop in props:
         if prop.get("property_id") == prop_id:
-            if as_uri:
-                return f"[{prop.get('o:label', '')}]({prop.get('@id', '')})"
+            if as_label:
+                return prop.get("o:label", "")
             return prop.get("@value", "")
     return ""
 
@@ -188,7 +188,7 @@ def extract_item_data(item):
         "publisher": extract_combined_values(item.get("dcterms:publisher", [])),
         "source": extract_combined_values(item.get("dcterms:source", [])),
         "date": extract_property(item.get("dcterms:date", []), 7),
-        "type": extract_property(item.get("dcterms:type", []), 8, as_uri=True),
+        "type": extract_property(item.get("dcterms:type", []), 8, as_label=True),
         "format": extract_property(item.get("dcterms:format", []), 9),
         "extent": extract_property(item.get("dcterms:extent", []), 25),
         "language": extract_property(item.get("dcterms:language", []), 12),
@@ -241,7 +241,7 @@ def extract_media_data(media, item_dc_identifier):
         "publisher": extract_combined_values(media.get("dcterms:publisher", [])),
         "source": extract_combined_values(media.get("dcterms:source", [])),
         "date": extract_property(media.get("dcterms:date", []), 7),
-        "type": extract_property(media.get("dcterms:type", []), 8, as_uri=True),
+        "type": extract_property(media.get("dcterms:type", []), 8, as_label=True),
         "format": format_value,
         "extent": extract_property(media.get("dcterms:extent", []), 25),
         "language": extract_property(media.get("dcterms:language", []), 12),

--- a/_data/config-metadata.csv
+++ b/_data/config-metadata.csv
@@ -9,7 +9,7 @@ creator,Ersteller*in,,true,DCTERMS.creator,creator
 date,Datum <a href='/data.html#edtf'>ℹ️<a>,,,DCTERMS.date,dateCreated
 source,Quelle,,true,DCTERMS.source,
 publisher,Verantwortliche Gedächtnisinstitution,,true,DCTERMS.publisher,publisher
-type,Typ,,true,DCTERMS.type,
+type,Typ,,,DCTERMS.type,
 format,Format,,,DCTERMS.format,encodingFormat
 extent,Auflösung,,,DCTERMS.extent,
 language,Sprache,,,DCTERMS.language,inLanguage


### PR DESCRIPTION
# Pull request

## Proposed changes

Pre-archival cleanup, two small changes:

- **Fixes #252**: remove the daily cron trigger from `.github/workflows/jekyll.yml`. `workflow_dispatch` (manual runs) and push-to-main triggers remain, so the site can still be rebuilt on demand before archival.
- **Fixes #209**: per the issue discussion ("What about not linking it at all?"), `dcterms:type` is no longer rendered as a link. `process_data.py` now emits the plain label (e.g. `Bild`) instead of a markdown link to the dcmitype URI, and `config-metadata.csv` no longer marks `type` as an external link. Takes effect with the next data run.

## Types of changes

- Enhancement

🤖 Generated with [Claude Code](https://claude.com/claude-code)