### PR TITLE
Fallback Display Template for Records

### DIFF
--- a/_includes/item/child/compound-item-modal-gallery.html
+++ b/_includes/item/child/compound-item-modal-gallery.html
@@ -156,7 +156,7 @@
                               </div>
                             {% elsif child.display_template == 'panorama' %}
                               {% include item/child/panorama.html %}
-                            {% elsif child.display_template == 'record' AND child.format == 'text/csv' %}
+                            {% elsif child.display_template == 'record' and child.format == 'text/csv' %}
                               {% include item/child/table.html %}
                             {% else %}
                               {% include item/child/item-thumb.html %}


### PR DESCRIPTION
# Pull request

## Proposed changes

* resolves #262 by fixing capitalization of liquid operators in modal gallery

In Omeka, I also changed the object IDs for dataset100359 children from `*-raw-csv` to `*_raw_csv` and deleted the `txt` record, instead linking to it as a related resource in the `csv` records.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [x] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a display condition in the child modal gallery so CSV record tables render correctly when the relevant display settings are selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->